### PR TITLE
fixing some typos in the ECS decom messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Important! Please read the following before using this notebook:
 
-**Warning: The data access method presented in this notebook works only for data sets on NSIDC DAAC’s on premise servers.**
+**Warning: The data access method presented in this notebook works only for data sets on NSIDC DAAC’s on premises servers.**
 
-The NSIDC DAAC is in the process of [migrating data to the NASA Earthdata Cloud](https://nsidc.org/data/user-resources/help-center/faqs-about-nsidc-daacs-earthdata-cloud-migration).  Data will continue to be available from our on-premise servers for a certain period of time, but will begin to be removed in June 2025.  We recommend adapting your workflow to access your data set of interest from the Earthdata Cloud archive as soon as possible.
+The NSIDC DAAC is in the process of [migrating data to the NASA Earthdata Cloud](https://nsidc.org/data/user-resources/help-center/faqs-about-nsidc-daacs-earthdata-cloud-migration).  Data will continue to be available from our legacy archive on our on-premise servers for a certain period of time, but will begin to be removed in June 2025.  We recommend adapting your workflow to access your data set of interest from the Earthdata Cloud archive as soon as possible.
 
 Please refer to this page for the removal timeline: https://nsidc.org/data/user-resources/help-center/when-will-legacy-premises-archive-be-retired
 
 If you experience errors while running this notebook, it is possible that your data set of interest is now only available from the NASA Earthdata Cloud.  Please check the schedule linked above.
 
-NASA Harmony services are in development to provide subsetting and other customization for data archived in the Earthdata Cloud.  The pages below offer guidance on using Harmony and the Harmony API for access to cloud-hosted NASA NSIDC DAAC:
+NASA Harmony services are in development to provide subsetting and other customization of data archived in the Earthdata Cloud.  The pages below offer guidance on using Harmony and the Harmony API for access to cloud-hosted NASA NSIDC DAAC data:
 
 [Subsetting ICESat-2 Data Using NASA Harmony and the harmony-py library](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/tutorials/IS2_Harmony.html)
 
@@ -18,7 +18,7 @@ NASA Harmony services are in development to provide subsetting and other customi
 
 # NSIDC-Data-Access-Notebook
 
-A Jupyter notebook exploring data coverage, size, and customization service availability along with direct data download utilizing the NSIDC DAAC's Data Access and Service API. If you are new to Jupyter Notebooks, you can read the [documentation](https://jupyter-notebook.readthedocs.io/en/stable/index.html), or you can walk through the user interface tour once you have loaded the notebook by selecting Help -> User Interface Tour in the menubar.
+A Jupyter notebook exploring data coverage, size, and customization service availability along with direct data download utilizing the NSIDC DAAC's Data Access and Service API for the NSIDC DAAC legacy on premises servers. If you are new to Jupyter Notebooks, you can read the [documentation](https://jupyter-notebook.readthedocs.io/en/stable/index.html), or you can walk through the user interface tour once you have loaded the notebook by selecting Help -> User Interface Tour in the menubar.
 
 This notebook was originally developed for the April 2019 USFS – NASA Joint Applications Workshop.
 

--- a/notebooks/Customize and Access NSIDC Data.ipynb
+++ b/notebooks/Customize and Access NSIDC Data.ipynb
@@ -1,20 +1,22 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Important! Please read the following before using this notebook:\n",
     "\n",
-    "**Warning: The data access method presented in this notebook works only for data sets on NSIDC DAAC’s on premise servers.**\n",
+    "**Warning: The data access method presented in this notebook works only for data sets on NSIDC DAAC’s on premises servers.**\n",
     "\n",
-    "The NSIDC DAAC is in the process of [migrating data to the NASA Earthdata Cloud](https://nsidc.org/data/user-resources/help-center/faqs-about-nsidc-daacs-earthdata-cloud-migration).  Data will continue to be available from our on-premise servers for a certain period of time, but will begin to be removed in June 2025.  We recommend adapting your workflow to access your data set of interest from the Earthdata Cloud archive as soon as possible.\n",
+    "The NSIDC DAAC is in the process of [migrating data to the NASA Earthdata Cloud](https://nsidc.org/data/user-resources/help-center/faqs-about-nsidc-daacs-earthdata-cloud-migration).  Data will continue to be available from our legacy archive on our on-premises servers for a certain period of time, but access will begin to be removed in June 2025.  We recommend adapting your workflow to access your data set of interest from the Earthdata Cloud archive as soon as possible.\n",
     "\n",
     "Please refer to this page for the removal timeline: https://nsidc.org/data/user-resources/help-center/when-will-legacy-premises-archive-be-retired\n",
     "\n",
     "If you experience errors while running this notebook, it is possible that your data set of interest is now only available from the NASA Earthdata Cloud.  Please check the schedule linked above.\n",
     "\n",
-    "NASA Harmony services are in development to provide subsetting and other customization for data archived in the Earthdata Cloud.  The pages below offer guidance on using Harmony and the Harmony API for access to cloud-hosted NASA NSIDC DAAC:\n",
+    "NASA Harmony services are in development to provide subsetting and other customization of data archived in the Earthdata Cloud.  The pages below offer guidance on using Harmony and the Harmony API for access to cloud-hosted NASA NSIDC DAAC data:\n",
     "\n",
     "[Subsetting ICESat-2 Data Using NASA Harmony and the harmony-py library](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/tutorials/IS2_Harmony.html)\n",
     "\n",
@@ -24,8 +26,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Customize and Access NSIDC DAAC Data\n",
     "\n",


### PR DESCRIPTION
fixed some typos caught while rereading the new messaging at the top of the readme and notebook.